### PR TITLE
import path from os

### DIFF
--- a/StataLinux.py
+++ b/StataLinux.py
@@ -2,6 +2,7 @@ import sublime
 import sublime_plugin
 import subprocess
 from os import remove
+from os import path
 
 class StataLinuxCommand(sublime_plugin.TextCommand):
 	def run(self, edit):
@@ -9,12 +10,12 @@ class StataLinuxCommand(sublime_plugin.TextCommand):
 		region = self.view.line(self.view.sel()[0])
 		content = self.view.substr(region)
 		# Create temporary file with content to be run:
-		filepath = os.path.split(self.view.file_name())[0]
-		filename = os.path.join(filepath, "tempfile.do")
+		filepath = path.split(self.view.file_name())[0]
+		filename = path.join(filepath, "tempfile.do")
 		with open(filename, "w") as file:
 			file.write(content)
 		# Create and execute bash command:
-		sublime_stata_sh_path = os.path.join(sublime.packages_path(), "StataLinux", "sublime-stata.sh")
+		sublime_stata_sh_path = path.join(sublime.packages_path(), "StataLinux", "sublime-stata.sh")
 		cmd = "sh " + sublime_stata_sh_path + " " + '"' + filename + '"'
 		ret = subprocess.call(cmd, shell = True)
 		if ret != 0:
@@ -29,7 +30,7 @@ class StataLinuxAllCommand(sublime_plugin.TextCommand):
 		# Define current file as the one to be run:
 		filename = self.view.file_name()
 		# Create and execute bash command:
-		sublime_stata_sh_path = os.path.join(sublime.packages_path(), "StataLinux", "sublime-stata.sh")
+		sublime_stata_sh_path = path.join(sublime.packages_path(), "StataLinux", "sublime-stata.sh")
 		cmd = "sh " + sublime_stata_sh_path + " " + '"' + filename + '"'
 		ret = subprocess.call(cmd, shell = True)
 		if ret != 0:


### PR DESCRIPTION
Thank you so much for working on this.

This PR hopefully fixes a bug I was having. When using the Command Pallette to Run All, nothing happened and I would get in the console:

```python
Traceback (most recent call last):
  File "/opt/sublime_text/sublime_plugin.py", line 1088, in run_
    return self.run(edit)
  File "/home/luis/.config/sublime-text-3/Packages/StataLinux/StataLinux.py", line 32, in run
    sublime_stata_sh_path = os.path.join(sublime.packages_path(), "StataLinux", "sublime-stata.sh")
NameError: global name 'os' is not defined
```

Since os.path.join is being called but os not being imported, I add a line to specifically import path from os and fix the name of that command in the file. Seems to be working on my machine now.