### PR TITLE
improve xdotool window matching by regex instead of last

### DIFF
--- a/sublime-stata.sh
+++ b/sublime-stata.sh
@@ -5,8 +5,8 @@
 string='do ''"'$1'"'
 echo "${string}" | xclip -selection clipboard
 
-# Get Stata window ID (latest oppened?)
-winid_stata=$(xdotool search --classname "stata" | tail -1)
+# Get Stata window ID (first window that matches the regex)
+winid_stata=$(xdotool search --name --limit 1 "Stata/(IC|SE|MP)? 1[0-9]\.[0-9]")
 
 # Send string to Stata's command pane, selecting previous text and copying on top
 # Note: there is an issue with xdotool's clearmodifiers option (see https://github.com/jordansissel/xdotool/issues/43)


### PR DESCRIPTION
When the last window opened was a *graph window* (or other windows than the main one) the plugin might try to send the code to that window instead and the code doesn't evaluate. With this fix it behaves more consistently. 

**Note:** Only tested with `Stata16-SE`, so it might be good to try out with other flavors first. 
**note 2:** this is my first pull request... If I am doing something wrong, I will be happy to hear how I could do properly.