### PR TITLE
Add \n character before sending to tempfile.do

### DIFF
--- a/StataLinux.py
+++ b/StataLinux.py
@@ -16,7 +16,7 @@ class StataLinuxCommand(sublime_plugin.TextCommand):
 		filepath = path.split(self.view.file_name())[0]
 		filename = path.join(filepath, "tempfile.do")
 		with open(filename, "w") as file:
-			file.write(content)
+			file.write(content + "\n")
 		# Create and execute bash command:
 		sublime_stata_sh_path = path.join(sublime.packages_path(), "StataLinux", "sublime-stata.sh")
 		cmd = "sh " + sublime_stata_sh_path + " " + '"' + filename + '"'


### PR DESCRIPTION
Adding the newline character ensures tempfile.do runs, even when there's only one line sent to the file. 

I was having an issue where I couldn't send the line I had my cursor on without fully selecting it. Even then it would fail to run sometimes. I'm guessing it's because Stata requires an end-of-line character to actually run the line (which didn't exist when there's only one line selected).  This seems to have fixed it for me.